### PR TITLE
adjust/with-command-on-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
- add fetch-depth: 0 to checkout action
- ensures all git history is available for subsequent steps